### PR TITLE
Bugfix/issue body null

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -20,6 +20,10 @@ describe("getRemindersFromBody", () => {
 
     expect(getRemindersFromBody(body)).toEqual([expected]);
   });
+  test("Can handle body being null", () => {
+    const body = null;
+    expect(getRemindersFromBody(body)).toEqual([]);
+  });
 });
 
 describe("getPastDueReminders", () => {

--- a/utilities.js
+++ b/utilities.js
@@ -1,6 +1,9 @@
 const regex = /\r?\n\r?\n<!-- bot: (?<reminder>{"reminders":.*) -->/;
 
 function getRemindersFromBody(body) {
+  if (body === null)
+    return [];
+
   const match = body.match(regex);
 
   return match ? JSON.parse(match.groups.reminder).reminders : [];


### PR DESCRIPTION
When there is no description in the issue, the ``body`` will be ``null``, which causes the reminder-action check to fail. This PR fixes the issue.